### PR TITLE
feat: add support for reading generated sboms

### DIFF
--- a/images/sbomer-generator/Containerfile
+++ b/images/sbomer-generator/Containerfile
@@ -23,7 +23,8 @@ USER 65532
 COPY --chown=65532:0 images/sbomer-generator/settings.xml images/sbomer-generator/install.sh /workdir/
 RUN sh -c ./install.sh
 
-ENV SBOMER_DOMINO_DIR=/workdir
+ENV SBOMER_DOMINO_DIR="/workdir"
+ENV SBOMER_MAVEN_SETTINGS_XML_PATH="/workdir/settings.xml"
 
 COPY --chown=65532:0 cli/target/quarkus-app/lib/ /workdir/generator/lib/
 COPY --chown=65532:0 cli/target/quarkus-app/*.jar /workdir/generator/

--- a/k8s/components/service/resources/deployment.yaml
+++ b/k8s/components/service/resources/deployment.yaml
@@ -38,6 +38,8 @@ spec:
           name: sbomer
           imagePullPolicy: IfNotPresent
           env:
+            - name: SBOMER_SBOM_SBOM_DIR
+              value: "/data"
             - name: QUARKUS_DATASOURCE_USERNAME
               valueFrom:
                 secretKeyRef:
@@ -63,5 +65,10 @@ spec:
             - containerPort: 8080
               name: http
               protocol: TCP
-          volumeMounts: []
-      volumes: []
+          volumeMounts:
+            - mountPath: /data
+              name: sbomer-sboms
+      volumes:
+        - name: sbomer-sboms
+          persistentVolumeClaim:
+            claimName: sbomer-sboms

--- a/k8s/components/tekton/resources/task-generate.yaml
+++ b/k8s/components/tekton/resources/task-generate.yaml
@@ -74,6 +74,11 @@ spec:
         echo "Storing configuration in the $CONFIG_PATH file"
         echo "$(params.config)" | tee $CONFIG_PATH
 
-        echo "Running generation..."
-        exec /workdir/.sdkman/candidates/java/17/bin/java -Xms256m -Xmx512m -jar ./generator/quarkus-run.jar -v sbom auto generate --config $CONFIG_PATH --index "$(params.index)"
+        mkdir -p $(workspaces.data.path)/$(context.taskRun.name)
+        cd $(workspaces.data.path)/$(context.taskRun.name)
 
+        echo "Running generation..."
+        exec /workdir/.sdkman/candidates/java/17/bin/java -Xms256m -Xmx512m -jar /workdir/generator/quarkus-run.jar -v sbom auto generate --workdir /tmp/sbomer-workdir --config $CONFIG_PATH --index "$(params.index)"
+  workspaces:
+    - name: data
+      description: Workspace used to store the generated SBOMs

--- a/k8s/overlays/development/kustomization.yaml
+++ b/k8s/overlays/development/kustomization.yaml
@@ -44,6 +44,9 @@ components:
   - ../../components/database
   - ../../components/tekton-deployment
   - ../../components/tekton
+resources:
+  - resources/pv.yaml
+  - resources/pvc.yaml
 secretGenerator:
   - name: sbomer-postgres
     literals:

--- a/k8s/overlays/development/resources/pv.yaml
+++ b/k8s/overlays/development/resources/pv.yaml
@@ -1,0 +1,30 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2023 Red Hat, Inc., and individual contributors
+# as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: sbomer-sboms
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/tmp/something"

--- a/k8s/overlays/development/resources/pvc.yaml
+++ b/k8s/overlays/development/resources/pvc.yaml
@@ -1,0 +1,29 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2023 Red Hat, Inc., and individual contributors
+# as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sbomer-sboms
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/k8s/overlays/local/kustomization.yaml
+++ b/k8s/overlays/local/kustomization.yaml
@@ -59,6 +59,9 @@ components:
   - ../../components/tekton-deployment
   - ../../components/tekton
   - ../../components/service
+resources:
+  - resources/pv.yaml
+  - resources/pvc.yaml
 patchesStrategicMerge:
   - patches/cm.yaml
 secretGenerator:

--- a/k8s/overlays/local/resources/pv.yaml
+++ b/k8s/overlays/local/resources/pv.yaml
@@ -1,0 +1,30 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2023 Red Hat, Inc., and individual contributors
+# as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: sbomer-sboms
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/tmp/something"

--- a/k8s/overlays/local/resources/pvc.yaml
+++ b/k8s/overlays/local/resources/pvc.yaml
@@ -1,0 +1,29 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2023 Red Hat, Inc., and individual contributors
+# as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sbomer-sboms
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/k8s/overlays/targets/ocp/resources/pvc.yaml
+++ b/k8s/overlays/targets/ocp/resources/pvc.yaml
@@ -1,0 +1,28 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2023 Red Hat, Inc., and individual contributors
+# as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sbomer-sboms
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/GenerationRequest.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/GenerationRequest.java
@@ -59,6 +59,7 @@ import io.fabric8.kubernetes.model.annotation.Version;
 @Group("")
 public class GenerationRequest extends ConfigMap {
 
+    public static final String KEY_ID = "id";
     public static final String KEY_BUILD_ID = "build-id";
     public static final String KEY_STATUS = "status";
     public static final String KEY_CONFIG = "config";
@@ -75,6 +76,15 @@ public class GenerationRequest extends ConfigMap {
             String kind,
             ObjectMeta metadata) {
         super(apiVersion, binaryData, data, immutable, kind, metadata);
+    }
+
+    @JsonIgnore
+    public String getId() {
+        return getData().get(KEY_ID);
+    }
+
+    public void setId(String id) {
+        getData().put(KEY_ID, id);
     }
 
     @JsonIgnore

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/GenerationRequestBuilder.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/GenerationRequestBuilder.java
@@ -19,6 +19,8 @@ package org.jboss.sbomer.service.feature.sbom.k8s.model;
 
 import java.util.Optional;
 
+import org.jboss.sbomer.service.feature.sbom.model.RandomStringIdGenerator;
+
 import io.fabric8.kubernetes.api.builder.VisitableBuilder;
 
 public class GenerationRequestBuilder extends GenerationRequestFluentImpl<GenerationRequestBuilder>
@@ -26,6 +28,7 @@ public class GenerationRequestBuilder extends GenerationRequestFluentImpl<Genera
 
     @Override
     public GenerationRequest build() {
+        addToData(GenerationRequest.KEY_ID, RandomStringIdGenerator.generate());
         addToData(GenerationRequest.KEY_BUILD_ID, getBuildId());
         addToData(
                 GenerationRequest.KEY_STATUS,

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/GenerationRequestFluent.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/GenerationRequestFluent.java
@@ -21,6 +21,8 @@ import io.fabric8.kubernetes.api.model.ConfigMapFluent;
 
 public interface GenerationRequestFluent<A extends GenerationRequestFluent<A>> extends ConfigMapFluent<A> {
 
+    public A withId(String id);
+
     public A withBuildId(String buildId);
 
     public A withStatus(SbomGenerationStatus status);

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/GenerationRequestFluentImpl.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/GenerationRequestFluentImpl.java
@@ -27,6 +27,7 @@ import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 public class GenerationRequestFluentImpl<A extends GenerationRequestFluent<A>> extends ConfigMapFluentImpl<A>
         implements GenerationRequestFluent<A> {
 
+    private String id;
     private String buildId;
     private SbomGenerationStatus status;
 
@@ -48,6 +49,16 @@ public class GenerationRequestFluentImpl<A extends GenerationRequestFluent<A>> e
 
     public String getBuildId() {
         return buildId;
+    }
+
+    @Override
+    public A withId(String id) {
+        this.id = id;
+        return (A) this;
+    }
+
+    public String getId() {
+        return id;
     }
 
     @Override

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/resources/TaskRunGenerateDependentResource.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/resources/TaskRunGenerateDependentResource.java
@@ -36,11 +36,14 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimVolumeSourceBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.tekton.client.TektonClient;
 import io.fabric8.tekton.pipeline.v1beta1.ParamBuilder;
 import io.fabric8.tekton.pipeline.v1beta1.TaskRefBuilder;
 import io.fabric8.tekton.pipeline.v1beta1.TaskRun;
 import io.fabric8.tekton.pipeline.v1beta1.TaskRunBuilder;
+import io.fabric8.tekton.pipeline.v1beta1.WorkspaceBindingBuilder;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.processing.dependent.BulkDependentResource;
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent;
@@ -63,6 +66,9 @@ public class TaskRunGenerateDependentResource extends KubernetesDependentResourc
     public static final String PARAM_COMMAND_INDEX_NAME = "index";
 
     ObjectMapper objectMapper = ObjectMapperProvider.yaml();
+
+    @Inject
+    KubernetesClient kubernetesClient;
 
     @Inject
     TektonClient tektonClient;
@@ -140,6 +146,13 @@ public class TaskRunGenerateDependentResource extends KubernetesDependentResourc
                                 .withNewValue(String.valueOf(index))
                                 .build())
                 .withTaskRef(new TaskRefBuilder().withName("sbomer-generate").build())
+                .withWorkspaces(
+                        new WorkspaceBindingBuilder().withSubPath(generationRequest.getMetadata().getName())
+                                .withName("data")
+                                .withPersistentVolumeClaim(
+                                        new PersistentVolumeClaimVolumeSourceBuilder().withClaimName("sbomer-sboms")
+                                                .build())
+                                .build())
                 .endSpec()
                 .build();
 

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/model/RandomStringIdGenerator.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/model/RandomStringIdGenerator.java
@@ -1,0 +1,24 @@
+package org.jboss.sbomer.service.feature.sbom.model;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.id.IdentifierGenerator;
+
+/**
+ * 
+ */
+public class RandomStringIdGenerator implements IdentifierGenerator {
+
+	@Override
+	public Serializable generate(SharedSessionContractImplementor session, Object object) throws HibernateException {
+		return RandomStringIdGenerator.generate();
+	}
+
+	public static String generate() {
+		return UUID.randomUUID().toString().replaceAll("_", "").replaceAll("-", "").substring(0, 15).toUpperCase();
+	}
+
+}

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/model/SbomGenerationRequest.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/model/SbomGenerationRequest.java
@@ -10,12 +10,9 @@ import javax.persistence.Table;
 import javax.transaction.Transactional;
 
 import org.hibernate.annotations.DynamicUpdate;
-import org.hibernate.annotations.TypeDef;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequest;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationStatus;
 
-import io.quarkiverse.hibernate.types.json.JsonBinaryType;
-import io.quarkiverse.hibernate.types.json.JsonTypes;
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -28,7 +25,6 @@ import lombok.extern.slf4j.Slf4j;
 @Setter
 @EqualsAndHashCode(callSuper = true)
 @Entity
-@TypeDef(name = JsonTypes.JSON_BIN, typeClass = JsonBinaryType.class)
 @ToString
 @Table(
 		name = "sbom_generation_request",
@@ -67,10 +63,10 @@ public class SbomGenerationRequest extends PanacheEntityBase {
 
 			sbomGenerationRequest = new SbomGenerationRequest();
 			sbomGenerationRequest.setId(generationRequest.getId());
+			sbomGenerationRequest.setBuildId(generationRequest.getBuildId());
 		}
 
 		// Finally sync the SbomGenerationRequest entity with the GenerationRequest.
-		sbomGenerationRequest.setBuildId(generationRequest.getBuildId());
 		sbomGenerationRequest.setStatus(generationRequest.getStatus());
 
 		// Store it in the database

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/model/SbomGenerationRequest.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/model/SbomGenerationRequest.java
@@ -1,0 +1,87 @@
+package org.jboss.sbomer.service.feature.sbom.model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.Table;
+import javax.transaction.Transactional;
+
+import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.TypeDef;
+import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequest;
+import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationStatus;
+
+import io.quarkiverse.hibernate.types.json.JsonBinaryType;
+import io.quarkiverse.hibernate.types.json.JsonTypes;
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+@DynamicUpdate
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@TypeDef(name = JsonTypes.JSON_BIN, typeClass = JsonBinaryType.class)
+@ToString
+@Table(
+		name = "sbom_generation_request",
+		indexes = { @Index(name = "idx_request_buildid", columnList = "build_id"),
+				@Index(name = "idx_request_status", columnList = "status") })
+@Slf4j
+public class SbomGenerationRequest extends PanacheEntityBase {
+
+	@Id
+	@Column(nullable = false, updatable = false)
+	private String id;
+
+	@Column(name = "status", nullable = false)
+	@Enumerated(EnumType.STRING)
+	SbomGenerationStatus status;
+
+	@Column(name = "build_id", nullable = false, updatable = false)
+	String buildId;
+
+	/**
+	 * Method to sync the {@link GenerationRequest} Kubernetes resource with the {@link SbomGenerationRequest} entity in
+	 * the database.
+	 *
+	 * @param generationRequest
+	 * @return Updated {@link SbomGenerationRequest} entity
+	 */
+	@Transactional
+	public static SbomGenerationRequest sync(GenerationRequest generationRequest) {
+		SbomGenerationRequest sbomGenerationRequest = SbomGenerationRequest.findById(generationRequest.getId());
+
+		// Create the entity if it's not there
+		if (sbomGenerationRequest == null) {
+			log.debug(
+					"Could not find SbomGenerationRequest entity in the database for id '{}', creating new one",
+					generationRequest.getId());
+
+			sbomGenerationRequest = new SbomGenerationRequest();
+			sbomGenerationRequest.setId(generationRequest.getId());
+		}
+
+		// Finally sync the SbomGenerationRequest entity with the GenerationRequest.
+		sbomGenerationRequest.setBuildId(generationRequest.getBuildId());
+		sbomGenerationRequest.setStatus(generationRequest.getStatus());
+
+		// Store it in the database
+		sbomGenerationRequest.persistAndFlush();
+
+		log.debug(
+				"SbomGenerationRequest '{}' synced with GenerationRequest '{}'",
+				sbomGenerationRequest.getId(),
+				generationRequest.getMetadata().getName());
+
+		return sbomGenerationRequest;
+	}
+
+}

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -78,6 +78,10 @@ sbomer:
         topic: "${PRODUCER_TOPIC}"
         retries: 15
         max-back-off: 30
+
+  sbom:
+    sbom-dir: "${SBOMER_SBOM_DIR}"
+
   api-url: "https://${SBOMER_ROUTE_HOST}/api/v1alpha1/"
   # generation:
   #   enabled: true


### PR DESCRIPTION
Additionally:

* Create SbomGenerationRequest DB entity and sync it with the Kubernetes GenerationRequest
* Expose SbomGenerationRequest via REST API
* Update deployment scripts (untested)